### PR TITLE
fixed the DNS menu display

### DIFF
--- a/clr/Interactive.cpp
+++ b/clr/Interactive.cpp
@@ -636,9 +636,9 @@ bool Interactive::GenerateNewConfig()
 
 	Console::WriteLine("Please specify DNS servers to push to connecting clients:");
 	Console::WriteLine(String::Format("\t1 - CloudFlare ({0})", String::Join(" & ", cloudflareDNS)));
-	Console::WriteLine(String::Format("\t1 - Google ({0})", String::Join(" & ", googleDNS)));
-	Console::WriteLine(String::Format("\t1 - OpenDNS ({0})", String::Join(" & ", openDNS)));
-	Console::WriteLine(String::Format("\t1 - Local Server ({0}). You will need a DNS server running beside your VPN server", localDNS));
+	Console::WriteLine(String::Format("\t2 - Google ({0})", String::Join(" & ", googleDNS)));
+	Console::WriteLine(String::Format("\t3 - OpenDNS ({0})", String::Join(" & ", openDNS)));
+	Console::WriteLine(String::Format("\t4 - Local Server ({0}). You will need a DNS server running beside your VPN server", localDNS));
 	Console::WriteLine("\t5 - Custom");
 	Console::WriteLine("\t6 - None");
 	


### PR DESCRIPTION
Just a fix for the DNS menu display:

> Please specify DNS servers to push to connecting clients:
>        1 - CloudFlare (1.1.1.1 & 1.0.0.1)
>        1 - Google (8.8.8.8 & 8.8.4.4)
>        1 - OpenDNS (208.67.222.222 & 208.67.220.220)
>        1 - Local Server (10.8.0.1). You will need a DNS server running beside your VPN server
>        5 - Custom
>        6 - None

The options were actually tested properly.